### PR TITLE
Remove all setUp functions and calls to bootKernel

### DIFF
--- a/tests/BookStore/Functional/AnonymizeBooksTest.php
+++ b/tests/BookStore/Functional/AnonymizeBooksTest.php
@@ -13,11 +13,6 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 final class AnonymizeBooksTest extends KernelTestCase
 {
-    protected function setUp(): void
-    {
-        static::bootKernel();
-    }
-
     public function testAnonymizeAuthorOfBooks(): void
     {
         /** @var BookRepositoryInterface $bookRepository */

--- a/tests/BookStore/Functional/CreateBookTest.php
+++ b/tests/BookStore/Functional/CreateBookTest.php
@@ -16,11 +16,6 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 final class CreateBookTest extends KernelTestCase
 {
-    protected function setUp(): void
-    {
-        static::bootKernel();
-    }
-
     public function testCreateBook(): void
     {
         /** @var BookRepositoryInterface $bookRepository */

--- a/tests/BookStore/Functional/DeleteBookTest.php
+++ b/tests/BookStore/Functional/DeleteBookTest.php
@@ -12,11 +12,6 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 final class DeleteBookTest extends KernelTestCase
 {
-    protected function setUp(): void
-    {
-        static::bootKernel();
-    }
-
     public function testDeleteBook(): void
     {
         /** @var BookRepositoryInterface $bookRepository */

--- a/tests/BookStore/Functional/DiscountBookTest.php
+++ b/tests/BookStore/Functional/DiscountBookTest.php
@@ -14,11 +14,6 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 final class DiscountBookTest extends KernelTestCase
 {
-    protected function setUp(): void
-    {
-        static::bootKernel();
-    }
-
     /**
      * @dataProvider applyADiscountOnBookDataProvider
      */

--- a/tests/BookStore/Functional/FindBookTest.php
+++ b/tests/BookStore/Functional/FindBookTest.php
@@ -12,11 +12,6 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 final class FindBookTest extends KernelTestCase
 {
-    protected function setUp(): void
-    {
-        static::bootKernel();
-    }
-
     public function testFindBook(): void
     {
         /** @var BookRepositoryInterface $bookRepository */

--- a/tests/BookStore/Functional/FindBooksTest.php
+++ b/tests/BookStore/Functional/FindBooksTest.php
@@ -13,11 +13,6 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 final class FindBooksTest extends KernelTestCase
 {
-    protected function setUp(): void
-    {
-        static::bootKernel();
-    }
-
     public function testFindBooks(): void
     {
         /** @var BookRepositoryInterface $bookRepository */

--- a/tests/BookStore/Functional/FindCheapestBooksTest.php
+++ b/tests/BookStore/Functional/FindCheapestBooksTest.php
@@ -13,11 +13,6 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 final class FindCheapestBooksTest extends KernelTestCase
 {
-    protected function setUp(): void
-    {
-        static::bootKernel();
-    }
-
     public function testReturnOnlyTheCheapestBooks(): void
     {
         /** @var BookRepositoryInterface $bookRepository */

--- a/tests/BookStore/Functional/UpdateBookTest.php
+++ b/tests/BookStore/Functional/UpdateBookTest.php
@@ -17,11 +17,6 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 final class UpdateBookTest extends KernelTestCase
 {
-    protected function setUp(): void
-    {
-        static::bootKernel();
-    }
-
     public function testUpdateBook(): void
     {
         /** @var BookRepositoryInterface $bookRepository */

--- a/tests/BookStore/Integration/Doctrine/DoctrineBookRepositoryTest.php
+++ b/tests/BookStore/Integration/Doctrine/DoctrineBookRepositoryTest.php
@@ -22,8 +22,6 @@ final class DoctrineBookRepositoryTest extends KernelTestCase
     {
         parent::setUpBeforeClass();
 
-        static::bootKernel();
-
         static::$connection = static::getContainer()->get(Connection::class);
 
         (new Application(static::$kernel))
@@ -37,7 +35,6 @@ final class DoctrineBookRepositoryTest extends KernelTestCase
 
     protected function setUp(): void
     {
-        static::bootKernel();
         static::$connection->executeStatement('TRUNCATE book');
     }
 

--- a/tests/BookStore/Integration/InMemory/InMemoryBookRepositoryTest.php
+++ b/tests/BookStore/Integration/InMemory/InMemoryBookRepositoryTest.php
@@ -12,11 +12,6 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 final class InMemoryBookRepositoryTest extends KernelTestCase
 {
-    protected function setUp(): void
-    {
-        static::bootKernel();
-    }
-
     public function testAdd(): void
     {
         /** @var InMemoryBookRepository $repository */

--- a/tests/Subscription/Acceptance/SubscriptionCrudTest.php
+++ b/tests/Subscription/Acceptance/SubscriptionCrudTest.php
@@ -22,8 +22,6 @@ final class SubscriptionCrudTest extends ApiTestCase
     {
         parent::setUpBeforeClass();
 
-        static::bootKernel();
-
         static::$connection = static::getContainer()->get(Connection::class);
 
         (new Application(static::$kernel))
@@ -37,7 +35,6 @@ final class SubscriptionCrudTest extends ApiTestCase
 
     protected function setUp(): void
     {
-        static::bootKernel();
         static::$connection->executeStatement('TRUNCATE subscription');
     }
 


### PR DESCRIPTION
With `static::getContainer()`, overriding the `setUp` method for calling `bootKernel` is not needed anymore.
The method `getContainer` already verifies the kernel is up before reaching the it.