### PR TITLE
fix(shared): Turn base `AggregateRootId` into a trait

### DIFF
--- a/src/BookStore/Domain/ValueObject/BookId.php
+++ b/src/BookStore/Domain/ValueObject/BookId.php
@@ -8,6 +8,7 @@ use App\Shared\Domain\ValueObject\AggregateRootId;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Embeddable]
-final class BookId extends AggregateRootId
+final class BookId implements \Stringable
 {
+    use AggregateRootId;
 }

--- a/src/Shared/Domain/ValueObject/AggregateRootId.php
+++ b/src/Shared/Domain/ValueObject/AggregateRootId.php
@@ -8,7 +8,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Uid\AbstractUid;
 use Symfony\Component\Uid\Uuid;
 
-abstract class AggregateRootId implements \Stringable
+trait AggregateRootId
 {
     #[ORM\Id]
     #[ORM\Column(name: 'id', type: 'uuid')]

--- a/tests/BookStore/Integration/Doctrine/DoctrineBookRepositoryTest.php
+++ b/tests/BookStore/Integration/Doctrine/DoctrineBookRepositoryTest.php
@@ -9,6 +9,7 @@ use App\BookStore\Infrastructure\Doctrine\DoctrineBookRepository;
 use App\Shared\Infrastructure\Doctrine\DoctrinePaginator;
 use App\Tests\BookStore\DummyFactory\DummyBookFactory;
 use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -75,7 +76,9 @@ final class DoctrineBookRepositoryTest extends KernelTestCase
         $book = DummyBookFactory::createBook();
         $repository->save($book);
 
-        static::assertSame($book, $repository->ofId($book->id));
+        static::getContainer()->get(EntityManagerInterface::class)->clear();
+
+        static::assertEquals($book, $repository->ofId($book->id));
     }
 
     public function testWithAuthor(): void


### PR DESCRIPTION
My proposal to fix #25. Not sure why this bug isn't caught by `DoctrineBookRepositoryTest` nor how we can make it able to do so. 💡 welcome