### PR TITLE
chore: update Dockerfile to fix Caddy version to 2.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 
 # https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
 ARG PHP_VERSION=8.2
-ARG CADDY_VERSION=2
+ARG CADDY_VERSION=2.7
 
 # "php" stage
 FROM php:${PHP_VERSION}-fpm-alpine AS symfony_php


### PR DESCRIPTION
Fixes the following error encountered during install: `crypto/ecdh: package crypto/ecdh is not in GOROOT`.

See https://github.com/dunglas/mercure/issues/770#issuecomment-1558154310