### PR TITLE
fix: rely on doctrine paginator for counting

### DIFF
--- a/src/Shared/Infrastructure/Doctrine/DoctrineRepository.php
+++ b/src/Shared/Infrastructure/Doctrine/DoctrineRepository.php
@@ -46,14 +46,9 @@ abstract class DoctrineRepository implements RepositoryInterface
 
     public function count(): int
     {
-        if (null !== $paginator = $this->paginator()) {
-            return count($paginator);
-        }
+        $paginator = $this->paginator() ?? new Paginator(clone $this->queryBuilder);
 
-        return (int) (clone $this->queryBuilder)
-            ->select('count(1)')
-            ->getQuery()
-            ->getSingleScalarResult();
+        return count($paginator);
     }
 
     public function paginator(): ?PaginatorInterface


### PR DESCRIPTION
As pointed out by @Brewal, we better have to rely on Doctrine's `Paginator` when counting even if there is no pagination, so that joins are handled properly.

Fixes #49.