### PR TITLE
Improve CQS System

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -19,6 +19,9 @@ return (new PhpCsFixer\Config())
         ],
         'declare_strict_types' => true,
         'nullable_type_declaration_for_default_null_value' => false,
+        'phpdoc_to_comment' => [
+            'ignored_tags' => ['var'],
+        ],
     ])
     ->setRiskyAllowed(true)
     ->setFinder($finder)

--- a/config/packages/framework.php
+++ b/config/packages/framework.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\BookStore\Domain\Exception\MissingBookException;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
@@ -19,6 +20,11 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ],
             'php_errors' => [
                 'log' => 4096,
+            ],
+            'exceptions' => [
+                MissingBookException::class => [
+                    'status_code' => 404,
+                ],
             ],
         ],
     );

--- a/src/BookStore/Application/Command/AnonymizeBooksCommand.php
+++ b/src/BookStore/Application/Command/AnonymizeBooksCommand.php
@@ -6,6 +6,9 @@ namespace App\BookStore\Application\Command;
 
 use App\Shared\Application\Command\CommandInterface;
 
+/**
+ * @implements CommandInterface<void>
+ */
 final readonly class AnonymizeBooksCommand implements CommandInterface
 {
     public function __construct(

--- a/src/BookStore/Application/Command/AnonymizeBooksCommandHandler.php
+++ b/src/BookStore/Application/Command/AnonymizeBooksCommandHandler.php
@@ -6,9 +6,10 @@ namespace App\BookStore\Application\Command;
 
 use App\BookStore\Domain\Repository\BookRepositoryInterface;
 use App\BookStore\Domain\ValueObject\Author;
-use App\Shared\Application\Command\CommandHandlerInterface;
+use App\Shared\Application\Command\AsCommandHandler;
 
-final readonly class AnonymizeBooksCommandHandler implements CommandHandlerInterface
+#[AsCommandHandler]
+final readonly class AnonymizeBooksCommandHandler
 {
     public function __construct(private BookRepositoryInterface $bookRepository)
     {

--- a/src/BookStore/Application/Command/CreateBookCommand.php
+++ b/src/BookStore/Application/Command/CreateBookCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\BookStore\Application\Command;
 
+use App\BookStore\Domain\Model\Book;
 use App\BookStore\Domain\ValueObject\Author;
 use App\BookStore\Domain\ValueObject\BookContent;
 use App\BookStore\Domain\ValueObject\BookDescription;
@@ -11,6 +12,9 @@ use App\BookStore\Domain\ValueObject\BookName;
 use App\BookStore\Domain\ValueObject\Price;
 use App\Shared\Application\Command\CommandInterface;
 
+/**
+ * @implements CommandInterface<Book>
+ */
 final readonly class CreateBookCommand implements CommandInterface
 {
     public function __construct(

--- a/src/BookStore/Application/Command/CreateBookCommandHandler.php
+++ b/src/BookStore/Application/Command/CreateBookCommandHandler.php
@@ -6,9 +6,10 @@ namespace App\BookStore\Application\Command;
 
 use App\BookStore\Domain\Model\Book;
 use App\BookStore\Domain\Repository\BookRepositoryInterface;
-use App\Shared\Application\Command\CommandHandlerInterface;
+use App\Shared\Application\Command\AsCommandHandler;
 
-final readonly class CreateBookCommandHandler implements CommandHandlerInterface
+#[AsCommandHandler]
+final readonly class CreateBookCommandHandler
 {
     public function __construct(private readonly BookRepositoryInterface $bookRepository)
     {

--- a/src/BookStore/Application/Command/DeleteBookCommand.php
+++ b/src/BookStore/Application/Command/DeleteBookCommand.php
@@ -7,6 +7,9 @@ namespace App\BookStore\Application\Command;
 use App\BookStore\Domain\ValueObject\BookId;
 use App\Shared\Application\Command\CommandInterface;
 
+/**
+ * @implements CommandInterface<void>
+ */
 final readonly class DeleteBookCommand implements CommandInterface
 {
     public function __construct(

--- a/src/BookStore/Application/Command/DeleteBookCommandHandler.php
+++ b/src/BookStore/Application/Command/DeleteBookCommandHandler.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace App\BookStore\Application\Command;
 
 use App\BookStore\Domain\Repository\BookRepositoryInterface;
-use App\Shared\Application\Command\CommandHandlerInterface;
+use App\Shared\Application\Command\AsCommandHandler;
 
-final readonly class DeleteBookCommandHandler implements CommandHandlerInterface
+#[AsCommandHandler]
+final readonly class DeleteBookCommandHandler
 {
     public function __construct(private BookRepositoryInterface $bookRepository)
     {

--- a/src/BookStore/Application/Command/DiscountBookCommand.php
+++ b/src/BookStore/Application/Command/DiscountBookCommand.php
@@ -8,6 +8,9 @@ use App\BookStore\Domain\ValueObject\BookId;
 use App\BookStore\Domain\ValueObject\Discount;
 use App\Shared\Application\Command\CommandInterface;
 
+/**
+ * @implements CommandInterface<void>
+ */
 final readonly class DiscountBookCommand implements CommandInterface
 {
     public function __construct(

--- a/src/BookStore/Application/Command/DiscountBookCommandHandler.php
+++ b/src/BookStore/Application/Command/DiscountBookCommandHandler.php
@@ -6,9 +6,10 @@ namespace App\BookStore\Application\Command;
 
 use App\BookStore\Domain\Exception\MissingBookException;
 use App\BookStore\Domain\Repository\BookRepositoryInterface;
-use App\Shared\Application\Command\CommandHandlerInterface;
+use App\Shared\Application\Command\AsCommandHandler;
 
-final readonly class DiscountBookCommandHandler implements CommandHandlerInterface
+#[AsCommandHandler]
+final readonly class DiscountBookCommandHandler
 {
     public function __construct(private BookRepositoryInterface $bookRepository)
     {

--- a/src/BookStore/Application/Command/UpdateBookCommand.php
+++ b/src/BookStore/Application/Command/UpdateBookCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\BookStore\Application\Command;
 
+use App\BookStore\Domain\Model\Book;
 use App\BookStore\Domain\ValueObject\Author;
 use App\BookStore\Domain\ValueObject\BookContent;
 use App\BookStore\Domain\ValueObject\BookDescription;
@@ -12,6 +13,9 @@ use App\BookStore\Domain\ValueObject\BookName;
 use App\BookStore\Domain\ValueObject\Price;
 use App\Shared\Application\Command\CommandInterface;
 
+/**
+ * @implements CommandInterface<Book>
+ */
 final readonly class UpdateBookCommand implements CommandInterface
 {
     public function __construct(

--- a/src/BookStore/Application/Command/UpdateBookCommandHandler.php
+++ b/src/BookStore/Application/Command/UpdateBookCommandHandler.php
@@ -7,9 +7,10 @@ namespace App\BookStore\Application\Command;
 use App\BookStore\Domain\Exception\MissingBookException;
 use App\BookStore\Domain\Model\Book;
 use App\BookStore\Domain\Repository\BookRepositoryInterface;
-use App\Shared\Application\Command\CommandHandlerInterface;
+use App\Shared\Application\Command\AsCommandHandler;
 
-final readonly class UpdateBookCommandHandler implements CommandHandlerInterface
+#[AsCommandHandler]
+final readonly class UpdateBookCommandHandler
 {
     public function __construct(private BookRepositoryInterface $bookRepository)
     {

--- a/src/BookStore/Application/Query/FindBookQuery.php
+++ b/src/BookStore/Application/Query/FindBookQuery.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace App\BookStore\Application\Query;
 
+use App\BookStore\Domain\Model\Book;
 use App\BookStore\Domain\ValueObject\BookId;
 use App\Shared\Application\Query\QueryInterface;
 
+/**
+ * @implements QueryInterface<Book>
+ */
 final readonly class FindBookQuery implements QueryInterface
 {
     public function __construct(

--- a/src/BookStore/Application/Query/FindBookQueryHandler.php
+++ b/src/BookStore/Application/Query/FindBookQueryHandler.php
@@ -4,18 +4,25 @@ declare(strict_types=1);
 
 namespace App\BookStore\Application\Query;
 
+use App\BookStore\Domain\Exception\MissingBookException;
 use App\BookStore\Domain\Model\Book;
 use App\BookStore\Domain\Repository\BookRepositoryInterface;
-use App\Shared\Application\Query\QueryHandlerInterface;
+use App\Shared\Application\Query\AsQueryHandler;
 
-final readonly class FindBookQueryHandler implements QueryHandlerInterface
+#[AsQueryHandler]
+final readonly class FindBookQueryHandler
 {
     public function __construct(private BookRepositoryInterface $repository)
     {
     }
 
-    public function __invoke(FindBookQuery $query): ?Book
+    public function __invoke(FindBookQuery $query): Book
     {
-        return $this->repository->ofId($query->id);
+        $book = $this->repository->ofId($query->id);
+        if (null === $book) {
+            throw new MissingBookException($query->id);
+        }
+
+        return $book;
     }
 }

--- a/src/BookStore/Application/Query/FindBooksQuery.php
+++ b/src/BookStore/Application/Query/FindBooksQuery.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace App\BookStore\Application\Query;
 
+use App\BookStore\Domain\Repository\BookRepositoryInterface;
 use App\BookStore\Domain\ValueObject\Author;
 use App\Shared\Application\Query\QueryInterface;
 
+/**
+ * @implements QueryInterface<BookRepositoryInterface>
+ */
 final readonly class FindBooksQuery implements QueryInterface
 {
     public function __construct(

--- a/src/BookStore/Application/Query/FindBooksQueryHandler.php
+++ b/src/BookStore/Application/Query/FindBooksQueryHandler.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace App\BookStore\Application\Query;
 
 use App\BookStore\Domain\Repository\BookRepositoryInterface;
-use App\Shared\Application\Query\QueryHandlerInterface;
+use App\Shared\Application\Query\AsQueryHandler;
 
-final readonly class FindBooksQueryHandler implements QueryHandlerInterface
+#[AsQueryHandler]
+final readonly class FindBooksQueryHandler
 {
     public function __construct(private BookRepositoryInterface $bookRepository)
     {

--- a/src/BookStore/Application/Query/FindCheapestBooksQuery.php
+++ b/src/BookStore/Application/Query/FindCheapestBooksQuery.php
@@ -4,8 +4,12 @@ declare(strict_types=1);
 
 namespace App\BookStore\Application\Query;
 
+use App\BookStore\Domain\Repository\BookRepositoryInterface;
 use App\Shared\Application\Query\QueryInterface;
 
+/**
+ * @implements QueryInterface<BookRepositoryInterface>
+ */
 final readonly class FindCheapestBooksQuery implements QueryInterface
 {
     public function __construct(public int $size = 10)

--- a/src/BookStore/Application/Query/FindCheapestBooksQueryHandler.php
+++ b/src/BookStore/Application/Query/FindCheapestBooksQueryHandler.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace App\BookStore\Application\Query;
 
 use App\BookStore\Domain\Repository\BookRepositoryInterface;
-use App\Shared\Application\Query\QueryHandlerInterface;
+use App\Shared\Application\Query\AsQueryHandler;
 
-final readonly class FindCheapestBooksQueryHandler implements QueryHandlerInterface
+#[AsQueryHandler]
+final readonly class FindCheapestBooksQueryHandler
 {
     public function __construct(private BookRepositoryInterface $bookRepository)
     {

--- a/src/BookStore/Infrastructure/ApiPlatform/Resource/BookResource.php
+++ b/src/BookStore/Infrastructure/ApiPlatform/Resource/BookResource.php
@@ -110,7 +110,7 @@ final class BookResource
     ) {
     }
 
-    public static function fromModel(Book $book): static
+    public static function fromModel(Book $book): self
     {
         return new self(
             $book->id()->value,

--- a/src/BookStore/Infrastructure/ApiPlatform/State/Processor/CreateBookProcessor.php
+++ b/src/BookStore/Infrastructure/ApiPlatform/State/Processor/CreateBookProcessor.php
@@ -7,7 +7,6 @@ namespace App\BookStore\Infrastructure\ApiPlatform\State\Processor;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use App\BookStore\Application\Command\CreateBookCommand;
-use App\BookStore\Domain\Model\Book;
 use App\BookStore\Domain\ValueObject\Author;
 use App\BookStore\Domain\ValueObject\BookContent;
 use App\BookStore\Domain\ValueObject\BookDescription;
@@ -45,7 +44,6 @@ final readonly class CreateBookProcessor implements ProcessorInterface
             new Price($data->price),
         );
 
-        /** @var Book $model */
         $model = $this->commandBus->dispatch($command);
 
         return BookResource::fromModel($model);

--- a/src/BookStore/Infrastructure/ApiPlatform/State/Processor/DiscountBookProcessor.php
+++ b/src/BookStore/Infrastructure/ApiPlatform/State/Processor/DiscountBookProcessor.php
@@ -8,7 +8,6 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use App\BookStore\Application\Command\DiscountBookCommand;
 use App\BookStore\Application\Query\FindBookQuery;
-use App\BookStore\Domain\Model\Book;
 use App\BookStore\Domain\ValueObject\BookId;
 use App\BookStore\Domain\ValueObject\Discount;
 use App\BookStore\Infrastructure\ApiPlatform\Payload\DiscountBookPayload;
@@ -42,7 +41,6 @@ final readonly class DiscountBookProcessor implements ProcessorInterface
 
         $this->commandBus->dispatch($command);
 
-        /** @var Book $model */
         $model = $this->queryBus->ask(new FindBookQuery($command->id));
 
         return BookResource::fromModel($model);

--- a/src/BookStore/Infrastructure/ApiPlatform/State/Processor/UpdateBookProcessor.php
+++ b/src/BookStore/Infrastructure/ApiPlatform/State/Processor/UpdateBookProcessor.php
@@ -7,7 +7,6 @@ namespace App\BookStore\Infrastructure\ApiPlatform\State\Processor;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use App\BookStore\Application\Command\UpdateBookCommand;
-use App\BookStore\Domain\Model\Book;
 use App\BookStore\Domain\ValueObject\Author;
 use App\BookStore\Domain\ValueObject\BookContent;
 use App\BookStore\Domain\ValueObject\BookDescription;
@@ -44,7 +43,6 @@ final readonly class UpdateBookProcessor implements ProcessorInterface
             null !== $data->price ? new Price($data->price) : null,
         );
 
-        /** @var Book $model */
         $model = $this->commandBus->dispatch($command);
 
         return BookResource::fromModel($model);

--- a/src/BookStore/Infrastructure/ApiPlatform/State/Provider/BookCollectionProvider.php
+++ b/src/BookStore/Infrastructure/ApiPlatform/State/Provider/BookCollectionProvider.php
@@ -8,7 +8,6 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\Pagination\Pagination;
 use ApiPlatform\State\ProviderInterface;
 use App\BookStore\Application\Query\FindBooksQuery;
-use App\BookStore\Domain\Repository\BookRepositoryInterface;
 use App\BookStore\Domain\ValueObject\Author;
 use App\BookStore\Infrastructure\ApiPlatform\Resource\BookResource;
 use App\Shared\Application\Query\QueryBusInterface;
@@ -39,7 +38,6 @@ final readonly class BookCollectionProvider implements ProviderInterface
             $limit = $this->pagination->getLimit($operation, $context);
         }
 
-        /** @var BookRepositoryInterface $models */
         $models = $this->queryBus->ask(new FindBooksQuery(null !== $author ? new Author($author) : null, $offset, $limit));
 
         $resources = [];

--- a/src/BookStore/Infrastructure/ApiPlatform/State/Provider/BookItemProvider.php
+++ b/src/BookStore/Infrastructure/ApiPlatform/State/Provider/BookItemProvider.php
@@ -7,7 +7,6 @@ namespace App\BookStore\Infrastructure\ApiPlatform\State\Provider;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use App\BookStore\Application\Query\FindBookQuery;
-use App\BookStore\Domain\Model\Book;
 use App\BookStore\Domain\ValueObject\BookId;
 use App\BookStore\Infrastructure\ApiPlatform\Resource\BookResource;
 use App\Shared\Application\Query\QueryBusInterface;
@@ -28,9 +27,8 @@ final readonly class BookItemProvider implements ProviderInterface
         /** @var string $id */
         $id = $uriVariables['id'];
 
-        /** @var Book|null $model */
         $model = $this->queryBus->ask(new FindBookQuery(new BookId(Uuid::fromString($id))));
 
-        return null !== $model ? BookResource::fromModel($model) : null;
+        return BookResource::fromModel($model);
     }
 }

--- a/src/BookStore/Infrastructure/ApiPlatform/State/Provider/CheapestBooksProvider.php
+++ b/src/BookStore/Infrastructure/ApiPlatform/State/Provider/CheapestBooksProvider.php
@@ -7,7 +7,6 @@ namespace App\BookStore\Infrastructure\ApiPlatform\State\Provider;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use App\BookStore\Application\Query\FindCheapestBooksQuery;
-use App\BookStore\Domain\Repository\BookRepositoryInterface;
 use App\BookStore\Infrastructure\ApiPlatform\Resource\BookResource;
 use App\Shared\Application\Query\QueryBusInterface;
 
@@ -25,7 +24,6 @@ final readonly class CheapestBooksProvider implements ProviderInterface
      */
     public function provide(Operation $operation, array $uriVariables = [], array $context = []): array
     {
-        /** @var BookRepositoryInterface $models */
         $models = $this->queryBus->ask(new FindCheapestBooksQuery());
 
         $resources = [];

--- a/src/Shared/Application/Command/AsCommandHandler.php
+++ b/src/Shared/Application/Command/AsCommandHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Shared\Application\Command;
 
-interface CommandHandlerInterface
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class AsCommandHandler
 {
 }

--- a/src/Shared/Application/Command/CommandBusInterface.php
+++ b/src/Shared/Application/Command/CommandBusInterface.php
@@ -6,5 +6,12 @@ namespace App\Shared\Application\Command;
 
 interface CommandBusInterface
 {
+    /**
+     * @template T
+     *
+     * @param CommandInterface<T> $command
+     *
+     * @return T
+     */
     public function dispatch(CommandInterface $command): mixed;
 }

--- a/src/Shared/Application/Command/CommandInterface.php
+++ b/src/Shared/Application/Command/CommandInterface.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace App\Shared\Application\Command;
 
+/**
+ * @template T
+ */
 interface CommandInterface
 {
 }

--- a/src/Shared/Application/Query/AsQueryHandler.php
+++ b/src/Shared/Application/Query/AsQueryHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Shared\Application\Query;
 
-interface QueryHandlerInterface
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class AsQueryHandler
 {
 }

--- a/src/Shared/Application/Query/QueryBusInterface.php
+++ b/src/Shared/Application/Query/QueryBusInterface.php
@@ -6,5 +6,12 @@ namespace App\Shared\Application\Query;
 
 interface QueryBusInterface
 {
+    /**
+     * @template T
+     *
+     * @param QueryInterface<T> $query
+     *
+     * @return T
+     */
     public function ask(QueryInterface $query): mixed;
 }

--- a/src/Shared/Application/Query/QueryInterface.php
+++ b/src/Shared/Application/Query/QueryInterface.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace App\Shared\Application\Query;
 
+/**
+ * @template T
+ */
 interface QueryInterface
 {
 }

--- a/src/Shared/Infrastructure/Symfony/Kernel.php
+++ b/src/Shared/Infrastructure/Symfony/Kernel.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace App\Shared\Infrastructure\Symfony;
 
-use App\Shared\Application\Command\CommandHandlerInterface;
-use App\Shared\Application\Query\QueryHandlerInterface;
+use App\Shared\Application\Command\AsCommandHandler;
+use App\Shared\Application\Query\AsQueryHandler;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
@@ -33,10 +34,12 @@ final class Kernel extends BaseKernel
 
     protected function build(ContainerBuilder $container): void
     {
-        $container->registerForAutoconfiguration(QueryHandlerInterface::class)
-            ->addTag('messenger.message_handler', ['bus' => 'query.bus']);
+        $container->registerAttributeForAutoconfiguration(AsQueryHandler::class, static function (ChildDefinition $definition): void {
+            $definition->addTag('messenger.message_handler', ['bus' => 'query.bus']);
+        });
 
-        $container->registerForAutoconfiguration(CommandHandlerInterface::class)
-            ->addTag('messenger.message_handler', ['bus' => 'command.bus']);
+        $container->registerAttributeForAutoconfiguration(AsCommandHandler::class, static function (ChildDefinition $definition): void {
+            $definition->addTag('messenger.message_handler', ['bus' => 'command.bus']);
+        });
     }
 }

--- a/src/Shared/Infrastructure/Symfony/Messenger/MessengerCommandBus.php
+++ b/src/Shared/Infrastructure/Symfony/Messenger/MessengerCommandBus.php
@@ -19,9 +19,17 @@ final class MessengerCommandBus implements CommandBusInterface
         $this->messageBus = $commandBus;
     }
 
+    /**
+     * @template T
+     *
+     * @param CommandInterface<T> $command
+     *
+     * @return T
+     */
     public function dispatch(CommandInterface $command): mixed
     {
         try {
+            /** @var T */
             return $this->handle($command);
         } catch (HandlerFailedException $e) {
             if ($exception = current($e->getWrappedExceptions())) {

--- a/src/Shared/Infrastructure/Symfony/Messenger/MessengerQueryBus.php
+++ b/src/Shared/Infrastructure/Symfony/Messenger/MessengerQueryBus.php
@@ -19,9 +19,17 @@ final class MessengerQueryBus implements QueryBusInterface
         $this->messageBus = $queryBus;
     }
 
+    /**
+     * @template T
+     *
+     * @param QueryInterface<T> $query
+     *
+     * @return T
+     */
     public function ask(QueryInterface $query): mixed
     {
         try {
+            /** @var T */
             return $this->handle($query);
         } catch (HandlerFailedException $e) {
             if ($exception = current($e->getWrappedExceptions())) {

--- a/tests/BookStore/Acceptance/BookCrudTest.php
+++ b/tests/BookStore/Acceptance/BookCrudTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Tests\BookStore\Acceptance;
 
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
-use App\BookStore\Domain\Model\Book;
 use App\BookStore\Domain\Repository\BookRepositoryInterface;
 use App\BookStore\Domain\ValueObject\Author;
 use App\BookStore\Domain\ValueObject\BookContent;
@@ -127,7 +126,6 @@ final class BookCrudTest extends ApiTestCase
 
         $id = new BookId(Uuid::fromString(str_replace('/api/books/', '', $response->toArray()['@id'])));
 
-        /** @var Book $book */
         $book = static::getContainer()->get(BookRepositoryInterface::class)->ofId($id);
 
         static::assertNotNull($book);

--- a/tests/BookStore/Functional/FindBooksTest.php
+++ b/tests/BookStore/Functional/FindBooksTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Tests\BookStore\Functional;
 
 use App\BookStore\Application\Query\FindBooksQuery;
-use App\BookStore\Domain\Model\Book;
 use App\BookStore\Domain\Repository\BookRepositoryInterface;
 use App\BookStore\Domain\ValueObject\Author;
 use App\Shared\Application\Query\QueryBusInterface;
@@ -56,7 +55,6 @@ final class FindBooksTest extends KernelTestCase
 
         static::assertCount(3, $bookRepository);
 
-        /** @var Book[] $books */
         $books = $queryBus->ask(new FindBooksQuery(author: new Author('authorOne')));
 
         static::assertCount(2, $books);

--- a/tests/BookStore/Functional/FindCheapestBooksTest.php
+++ b/tests/BookStore/Functional/FindCheapestBooksTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Tests\BookStore\Functional;
 
 use App\BookStore\Application\Query\FindCheapestBooksQuery;
-use App\BookStore\Domain\Model\Book;
 use App\BookStore\Domain\Repository\BookRepositoryInterface;
 use App\BookStore\Domain\ValueObject\Price;
 use App\Shared\Application\Query\QueryBusInterface;
@@ -44,7 +43,6 @@ final class FindCheapestBooksTest extends KernelTestCase
             $bookRepository->save(DummyBookFactory::createBook(price: $price));
         }
 
-        /** @var Book[] $cheapestBooks */
         $cheapestBooks = $queryBus->ask(new FindCheapestBooksQuery(3));
 
         $sortedPrices = [1000, 2000, 3000];

--- a/tests/BookStore/Integration/Doctrine/DoctrineBookRepositoryTest.php
+++ b/tests/BookStore/Integration/Doctrine/DoctrineBookRepositoryTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Tests\BookStore\Integration\Doctrine;
 
-use App\BookStore\Domain\Model\Book;
 use App\BookStore\Domain\ValueObject\Author;
 use App\BookStore\Infrastructure\Doctrine\DoctrineBookRepository;
 use App\Shared\Infrastructure\Doctrine\DoctrinePaginator;
@@ -105,7 +104,6 @@ final class DoctrineBookRepositoryTest extends KernelTestCase
         $repository->save(DummyBookFactory::createBook(price: 2));
 
         $prices = [];
-        /** @var Book $book */
         foreach ($repository->withCheapestsFirst() as $book) {
             $prices[] = $book->price()->amount;
         }

--- a/tests/BookStore/Integration/InMemory/InMemoryBookRepositoryTest.php
+++ b/tests/BookStore/Integration/InMemory/InMemoryBookRepositoryTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Tests\BookStore\Integration\InMemory;
 
-use App\BookStore\Domain\Model\Book;
 use App\BookStore\Domain\ValueObject\Author;
 use App\BookStore\Infrastructure\InMemory\InMemoryBookRepository;
 use App\Shared\Infrastructure\InMemory\InMemoryPaginator;
@@ -76,7 +75,6 @@ final class InMemoryBookRepositoryTest extends KernelTestCase
         $repository->save(DummyBookFactory::createBook(price: 2));
 
         $prices = [];
-        /** @var Book $book */
         foreach ($repository->withCheapestsFirst() as $book) {
             $prices[] = $book->price()->amount;
         }


### PR DESCRIPTION
This proposal contains several improvements:
- Using generic templates in Command/Query classes, so documenting the returned type for each dispatch/ask invocation is no longer necessary.
- Now `FindBookQuery` strictly returns a `Book` instance; otherwise, a `MissingBookException` is thrown. 
- The `MissingBookException` is mapped to return a 404 status code, so a clear exception message is now displayed.
- Replace `CommandHandlerInterface` with the `AsCommandHandler` attribute, and `QueryHandlerInterface` with the `AsQueryHandler` attribute. The reason behind this is the fact that these interfaces have no contract; they are used as metadata to configure the messenger handler only. So, in this case, we can now use attributes instead as they are intended for that purpose.