### PR TITLE
fix: Github Actions set-output deprecated

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -34,7 +34,7 @@ jobs:
 
             - name: Get composer cache directory
               id: composercache
-              run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+              run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
 
             - name: Cache dependencies
               uses: actions/cache@v3
@@ -63,7 +63,7 @@ jobs:
 
             - name: Get composer cache directory
               id: composercache
-              run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+              run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
 
             - name: Cache dependencies
               uses: actions/cache@v3
@@ -92,7 +92,7 @@ jobs:
 
             - name: Get composer cache directory
               id: composercache
-              run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+              run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
 
             - name: Cache dependencies
               uses: actions/cache@v3
@@ -136,7 +136,7 @@ jobs:
 
             - name: Get composer cache directory
               id: composercache
-              run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+              run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
 
             - name: Cache dependencies
               uses: actions/cache@v3


### PR DESCRIPTION
Fixing Github Actions deprecated about set-output https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

I was wondering if the "needs" is required for it to work but according to [sample](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-setting-an-output-parameter) it looks like no.