### PR TITLE
fix: bad indentation in security.php

### DIFF
--- a/config/packages/security.php
+++ b/config/packages/security.php
@@ -11,9 +11,9 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             PasswordAuthenticatedUserInterface::class => 'auto',
         ],
         'providers' => [
-                'users_in_memory' => [
-                    'memory' => null,
-                ],
+            'users_in_memory' => [
+                'memory' => null,
+            ],
         ],
         'firewalls' => [
             'dev' => [


### PR DESCRIPTION
According to Github Actions, there is an indentation issue to [security.php](https://github.com/mtarld/apip-ddd/pull/59/files#file-config-packages-security-php-L1)

It's corrected, but I wonder how it is possible that it's not detected locally, if you got an idea of why the behavior is different I can take a look at it later.